### PR TITLE
Entropy pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ generation cannot fail.
 ## Benchmarks ##
 
 ```
-BenchmarkRead32-4           	 5000000	       249 ns/op	 128.47 MB/s
-BenchmarkRead64K-4          	    3000	    497977 ns/op	 128.52 MB/s
-BenchmarkReadCrypto32-4     	  500000	      2737 ns/op	  11.69 MB/s
-BenchmarkReadCrypto64K-4    	     300	   4059629 ns/op	  15.76 MB/s
+BenchmarkRead32-4             	10000000	       207 ns/op	 153.94 MB/s
+BenchmarkRead512K-4           	     500	   3230813 ns/op	 158.47 MB/s
+BenchmarkReadCrypto32-4       	  500000	      2697 ns/op	  11.86 MB/s
+BenchmarkReadCrypto512K-4     	      50	  32161930 ns/op	  15.92 MB/s
 ```

--- a/fastrand_test.go
+++ b/fastrand_test.go
@@ -189,10 +189,10 @@ func BenchmarkRead32(b *testing.B) {
 	}
 }
 
-// BenchmarkRead64K benchmarks the speed of Read for larger slices.
-func BenchmarkRead64K(b *testing.B) {
-	b.SetBytes(64e3)
-	buf := make([]byte, 64e3)
+// BenchmarkRead512K benchmarks the speed of Read for larger slices.
+func BenchmarkRead512K(b *testing.B) {
+	b.SetBytes(512e3)
+	buf := make([]byte, 512e3)
 	for i := 0; i < b.N; i++ {
 		Read(buf)
 	}
@@ -223,15 +223,15 @@ func BenchmarkRead4Threads(b *testing.B) {
 	wg.Wait()
 }
 
-// BenchmarkRead4Threads64k benchmarks the speed of Read when it's being using
-// across four threads with 64kb read sizes.
-func BenchmarkRead4Threads64k(b *testing.B) {
+// BenchmarkRead4Threads512k benchmarks the speed of Read when it's being using
+// across four threads with 512kb read sizes.
+func BenchmarkRead4Threads512k(b *testing.B) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < 4; i++ {
 		wg.Add(1)
 		go func() {
-			buf := make([]byte, 64e3)
+			buf := make([]byte, 512e3)
 			<-start
 			for i := 0; i < b.N; i++ {
 				Read(buf)
@@ -239,7 +239,7 @@ func BenchmarkRead4Threads64k(b *testing.B) {
 			wg.Done()
 		}()
 	}
-	b.SetBytes(4 * 64e3)
+	b.SetBytes(4 * 512e3)
 	b.ResetTimer()
 
 	// Signal all threads to begin
@@ -273,15 +273,15 @@ func BenchmarkRead64Threads(b *testing.B) {
 	wg.Wait()
 }
 
-// BenchmarkRead64Threads64k benchmarks the speed of Read when it's being using
-// across 64 threads with 64kb read sizes.
+// BenchmarkRead64Threads512k benchmarks the speed of Read when it's being using
+// across 64 threads with 512kb read sizes.
 func BenchmarkRead64Threads64k(b *testing.B) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for i := 0; i < 64; i++ {
 		wg.Add(1)
 		go func() {
-			buf := make([]byte, 64e3)
+			buf := make([]byte, 512e3)
 			<-start
 			for i := 0; i < b.N; i++ {
 				Read(buf)
@@ -289,7 +289,7 @@ func BenchmarkRead64Threads64k(b *testing.B) {
 			wg.Done()
 		}()
 	}
-	b.SetBytes(64 * 64e3)
+	b.SetBytes(64 * 512e3)
 	b.ResetTimer()
 
 	// Signal all threads to begin
@@ -308,11 +308,11 @@ func BenchmarkReadCrypto32(b *testing.B) {
 	}
 }
 
-// BenchmarkReadCrypto64K benchmarks the speed of (crypto/rand).Read for larger
-// slices. This establishes a lower limit for BenchmarkRead64K.
-func BenchmarkReadCrypto64K(b *testing.B) {
-	b.SetBytes(64e3)
-	buf := make([]byte, 64e3)
+// BenchmarkReadCrypto512K benchmarks the speed of (crypto/rand).Read for larger
+// slices. This establishes a lower limit for BenchmarkRead512K.
+func BenchmarkReadCrypto512K(b *testing.B) {
+	b.SetBytes(512e3)
+	buf := make([]byte, 512e3)
 	for i := 0; i < b.N; i++ {
 		rand.Read(buf)
 	}
@@ -328,11 +328,11 @@ func BenchmarkReadMath32(b *testing.B) {
 	}
 }
 
-// BenchmarkReadMath64K benchmarks the speed of (math/rand).Read for larger
-// slices. This establishes an upper limit for BenchmarkRead64K.
-func BenchmarkReadMath64K(b *testing.B) {
-	b.SetBytes(64e3)
-	buf := make([]byte, 64e3)
+// BenchmarkReadMath512K benchmarks the speed of (math/rand).Read for larger
+// slices. This establishes an upper limit for BenchmarkRead512K.
+func BenchmarkReadMath512K(b *testing.B) {
+	b.SetBytes(512e3)
+	buf := make([]byte, 512e3)
 	for i := 0; i < b.N; i++ {
 		mrand.Read(buf)
 	}


### PR DESCRIPTION
Code largely copied from the `buffered-crypto` branch.

See the README.md diff for a benchmark comparison. Full new benchmarks:
```
BenchmarkRead32-4             	10000000	       207 ns/op	 153.94 MB/s
BenchmarkRead512K-4           	     500	   3230813 ns/op	 158.47 MB/s
BenchmarkRead4Threads-4       	 2000000	       945 ns/op	 135.32 MB/s
BenchmarkRead4Threads512k-4   	     100	  14697556 ns/op	 139.34 MB/s
BenchmarkRead64Threads-4      	  100000	     14889 ns/op	 137.55 MB/s
BenchmarkRead64Threads64k-4   	       5	 235147804 ns/op	 139.35 MB/s
BenchmarkReadCrypto32-4       	  500000	      2697 ns/op	  11.86 MB/s
BenchmarkReadCrypto512K-4     	      50	  32161930 ns/op	  15.92 MB/s
```
In short, the throughput stays roughly constant even with 64 consumers, which is cool.