### PR TITLE
remove possibility of error upon reseed

### DIFF
--- a/fastrand.go
+++ b/fastrand.go
@@ -60,7 +60,6 @@ func (r *randReader) fillEntropy() {
 		// protecting against a compromised RNG.
 		h.Reset()
 		h.Write(seed[:])
-		io.CopyN(h, rand.Reader, 64)
 		seed = h.Sum(seed[:0])
 	}
 }


### PR DESCRIPTION
there's an unchecked error in this io.CopyN. But I realized that you don't even need new entropy, you can just rehash the existing entropy because the underlying state has never been exposed.