### PR TITLE
add benchmarks using crypto/rand in parallel

### DIFF
--- a/fastrand_test.go
+++ b/fastrand_test.go
@@ -215,9 +215,9 @@ func BenchmarkRead4Threads(b *testing.B) {
 		}()
 	}
 	b.SetBytes(4 * 32)
-	b.ResetTimer()
 
 	// Signal all threads to begin
+	b.ResetTimer()
 	close(start)
 	// Wait for all threads to exit
 	wg.Wait()
@@ -240,9 +240,9 @@ func BenchmarkRead4Threads512k(b *testing.B) {
 		}()
 	}
 	b.SetBytes(4 * 512e3)
-	b.ResetTimer()
 
 	// Signal all threads to begin
+	b.ResetTimer()
 	close(start)
 	// Wait for all threads to exit
 	wg.Wait()
@@ -265,9 +265,9 @@ func BenchmarkRead64Threads(b *testing.B) {
 		}()
 	}
 	b.SetBytes(64 * 32)
-	b.ResetTimer()
 
 	// Signal all threads to begin
+	b.ResetTimer()
 	close(start)
 	// Wait for all threads to exit
 	wg.Wait()
@@ -290,9 +290,9 @@ func BenchmarkRead64Threads64k(b *testing.B) {
 		}()
 	}
 	b.SetBytes(64 * 512e3)
-	b.ResetTimer()
 
 	// Signal all threads to begin
+	b.ResetTimer()
 	close(start)
 	// Wait for all threads to exit
 	wg.Wait()
@@ -306,6 +306,118 @@ func BenchmarkReadCrypto32(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		rand.Read(buf)
 	}
+}
+
+// BenchmarkReadCrypto4Threads32 benchmarks the speed of rand.Read when its
+// being used across 4 threads with 32 byte read sizes.
+func BenchmarkReadCrypto4Threads32(b *testing.B) {
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			buf := make([]byte, 32)
+			<-start
+			for i := 0; i < b.N; i++ {
+				_, err := rand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	b.SetBytes(4 * 32)
+
+	// Signal all threads to begin
+	b.ResetTimer()
+	close(start)
+	// Wait for all threads to exit
+	wg.Wait()
+}
+
+// BenchmarkReadCrypto4Threads512k benchmarks the speed of rand.Read when its
+// being used across 4 threads with 512 kb read sizes.
+func BenchmarkReadCrypto4Threads512kb(b *testing.B) {
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			buf := make([]byte, 512e3)
+			<-start
+			for i := 0; i < b.N; i++ {
+				_, err := rand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	b.SetBytes(4 * 512e3)
+
+	// Signal all threads to begin
+	b.ResetTimer()
+	close(start)
+	// Wait for all threads to exit
+	wg.Wait()
+}
+
+// BenchmarkReadCrypto64Threads32 benchmarks the speed of rand.Read when its
+// being used across 4 threads with 32 byte read sizes.
+func BenchmarkReadCrypto64Threads32(b *testing.B) {
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			buf := make([]byte, 32)
+			<-start
+			for i := 0; i < b.N; i++ {
+				_, err := rand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	b.SetBytes(64 * 32)
+
+	// Signal all threads to begin
+	b.ResetTimer()
+	close(start)
+	// Wait for all threads to exit
+	wg.Wait()
+}
+
+// BenchmarkReadCrypto64Threads512k benchmarks the speed of rand.Read when its
+// being used across 4 threads with 512 kb read sizes.
+func BenchmarkReadCrypto64Threads512kb(b *testing.B) {
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			buf := make([]byte, 512e3)
+			<-start
+			for i := 0; i < b.N; i++ {
+				_, err := rand.Read(buf)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	b.SetBytes(64 * 512e3)
+
+	// Signal all threads to begin
+	b.ResetTimer()
+	close(start)
+	// Wait for all threads to exit
+	wg.Wait()
 }
 
 // BenchmarkReadCrypto512K benchmarks the speed of (crypto/rand).Read for larger


### PR DESCRIPTION
Reddit thread was complaining that we are comparing a single-threaded process to a multi-threaded process in our benchmarks, which is a fair complaint. I've added benchmarks which demonstrate that crypto/rand experiences no global speedup when called from multiple threads.

```
BenchmarkIntn-4                       	 5000000	       334 ns/op
BenchmarkIntnLarge-4                  	 3000000	       428 ns/op
BenchmarkRead32-4                     	 5000000	       301 ns/op	 106.28 MB/s
BenchmarkRead512K-4                   	     300	   4761134 ns/op	 107.54 MB/s
BenchmarkRead4Threads-4               	 1000000	      1237 ns/op	 103.46 MB/s
BenchmarkRead4Threads512k-4           	     100	  19328607 ns/op	 105.96 MB/s
BenchmarkRead64Threads-4              	  100000	     20052 ns/op	 102.13 MB/s
BenchmarkRead64Threads64k-4           	       5	 309287058 ns/op	 105.95 MB/s
BenchmarkReadCrypto32-4               	  300000	      4974 ns/op	   6.43 MB/s
BenchmarkReadCrypto4Threads32-4       	  100000	     17390 ns/op	   7.36 MB/s
BenchmarkReadCrypto4Threads512kb-4    	      10	 212458296 ns/op	   9.64 MB/s
BenchmarkReadCrypto64Threads32-4      	   10000	    265228 ns/op	   7.72 MB/s
BenchmarkReadCrypto64Threads512kb-4   	       1	3458830358 ns/op	   9.47 MB/s
BenchmarkReadCrypto512K-4             	      50	  35763163 ns/op	  14.32 MB/s
BenchmarkReadMath32-4                 	10000000	       127 ns/op	 250.92 MB/s
BenchmarkReadMath512K-4               	    1000	   1009473 ns/op	 507.20 MB/s
BenchmarkPerm32-4                     	  200000	     10503 ns/op
BenchmarkPermLarge4k-4                	    1000	   1333671 ns/op
PASS
ok  	github.com/NebulousLabs/fastrand	36.430s
```